### PR TITLE
Modification pour luminaires zwave type dimmer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1038,7 +1038,7 @@ JeedomPlatform.prototype.command = function(c, value, service, IDs) {
 					cmdId = element.id;
 					if (value == undefined) {
 						if (c == "turnOn") {
-							value = 99;
+							value = (element.generic_type == "LIGHT_SLIDER") ? 255 : 99;
 						} else if (c == "turnOff") {
 							value = 0;
 						}


### PR DESCRIPTION
J'avais des soucis pour mes éclairages (Zwave Dimmer) qui passait à 100% tout le temps avec l'app Maison d'Apple. Le fait d'envoyer un turn on 255 au lieu de 99 résoud le problème.
Il doit y avoir des incompatibilités avec cette modif, les dimmers non zwave ne doivent pas prendre en compte une valeur de 255.
De plus j'aimerais bien que la commande LIGHT ON envoie aussi une value à 255 mais j'ai pas trouvé comment faire.

Au final est il possible de faire cette modif uniquement si la Commande On de l'équipement Jeedom à un setvalue=255 ?